### PR TITLE
exit the container when started again

### DIFF
--- a/var/lib/lxc/android/pre-start.sh
+++ b/var/lib/lxc/android/pre-start.sh
@@ -16,6 +16,12 @@ mount_android_partitions() {
 	done
 }
 
+if [ -f "/tmp/lxc_android_once" ]; then
+    echo "lxc:android contianer had already been invoked.";
+    exit -255
+fi
+touch /tmp/lxc_android_once
+
 INITRD=/system/boot/android-ramdisk.img
 rm -Rf $LXC_ROOTFS_PATH
 mkdir -p $LXC_ROOTFS_PATH


### PR DESCRIPTION
this commit exits the container if the container is started again.
if the container has to be started again, unmount all the bound folders
which are mounted in mount_android_partitions function in the same file.