### PR TITLE
Add service for loading qcom wifi driver

### DIFF
--- a/lib/systemd/system/qcom-wifi.service
+++ b/lib/systemd/system/qcom-wifi.service
@@ -1,0 +1,12 @@
+[Unit]
+Wants=local-fs.target
+After=local-fs.target
+Description=Qualcomm WiFi setup
+ConditionPathExists=/dev/wcnss_wlan
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'echo 1 > /dev/wcnss_wlan || echo sta > /sys/module/wlan/parameters/fwpath || echo No wifi detected.'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Before the driver always needed to be loaded manually, with this it
should automatically try to load the qcom wifi drivers.

I have only tested it on the Xperia Z3 Tablet (scorpion), it uses the first command.

It didn't work for me with the option `ConditionPathExists=/dev/wcnss_wlan`. The condition always failed. If you have any ideas on how to improve this, please tell me.